### PR TITLE
Chore - Remove Netlify Plugin to Migrate to Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "usehooks-ts": "^3.1.1"
   },
   "devDependencies": {
-    "@netlify/vite-plugin-react-router": "^1.0.1",
     "@react-router/dev": "^7.5.3",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites":  [
+    {"source": "/(.*)", "destination": "/"}
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from "vite";
 import { reactRouter } from "@react-router/dev/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import tailwindcss from "@tailwindcss/vite";
-import netlifyPlugin from "@netlify/vite-plugin-react-router";
 
 export default defineConfig({
-  plugins: [tailwindcss(), reactRouter(), tsconfigPaths(), netlifyPlugin()],
+  plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+  base: "/",
 });


### PR DESCRIPTION
### Build configuration updates:
* Removed the `@netlify/vite-plugin-react-router` dependency from `package.json` as it is no longer used.
* Updated `vite.config.ts` to remove the `netlifyPlugin` from the plugins array and added a `base` property with the value `"/"`.

### Vercel integration:
* Added a `vercel.json` file with a rewrites configuration to redirect all routes to the root (`/`).